### PR TITLE
Fix <details> closing tag for job opening

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,7 @@ application security, security protocols, cryptography, etc…)
 <!-- yaspeller ignore:start -->
 ###### *ULT*
 <!-- yaspeller ignore:end -->
+</details>
 
 
 ## Principal Architect


### PR DESCRIPTION
The job opening for C++ and Node Engineer was missing a closing `<details>` tag, causing all other job descriptions under it to be hidden.